### PR TITLE
feat: Add buttons to buy multiple seeds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ import { setLanguage, t } from './modules/localization.js';
 import { DOM, renderAll, renderOrderTimers } from './modules/ui.js';
 import { plantSeed, harvestCrop, sellCrop, buyUpgrade, gameTick, buySeed, fulfillOrder, forceGenerateOrder, increaseTrust, buyBuilding, startProduction, devAddAllProducts, toggleBuildingAutomation, addXp } from './modules/game.js';
 import { player, field, warehouse, saveGameState, clearGameState, loadGameState } from './modules/state.js';
-import { leveling } from './modules/config.js';
+import { leveling, store } from './modules/config.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     let gameLoopInterval;
@@ -111,8 +111,25 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!e.target.classList.contains('buy-btn')) return;
 
         const itemName = e.target.dataset.itemName;
-        const input = e.target.previousElementSibling;
-        const amount = parseInt(input.value, 10);
+        const amountType = e.target.dataset.amount;
+        let amount = 0;
+
+        if (amountType === 'custom') {
+            const input = e.target.parentElement.querySelector('.buy-amount-input');
+            amount = parseInt(input.value, 10);
+        } else if (amountType === 'max') {
+            const item = store.find(i => i.name === itemName);
+            if (!item) return;
+            const finalPrice = Math.round(item.price * (1 - (player.upgrades.seedDiscount + player.npcBonuses.seedDiscount)));
+            if (finalPrice <= 0) {
+                amount = 9999; // Or some other large number if price is free
+            } else {
+                amount = Math.floor(player.money / finalPrice);
+            }
+        } else {
+            amount = parseInt(amountType, 10);
+        }
+
 
         if (buySeed(itemName, amount)) {
             renderAll();

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -157,8 +157,11 @@ function renderStore() {
                 <span>${priceHtml}</span>
             </div>
             <div class="store-actions">
-                <input type="number" class="buy-amount-input" min="1" value="1">
-                <button class="btn buy-btn" data-item-name="${item.name}">${t('btn_buy')}</button>
+                <input type="number" class="buy-amount-input" min="1" value="1" style="width: 50px;">
+                <button class="btn buy-btn" data-item-name="${item.name}" data-amount="custom">${t('btn_buy')}</button>
+                <button class="btn buy-btn" data-item-name="${item.name}" data-amount="10">10</button>
+                <button class="btn buy-btn" data-item-name="${item.name}" data-amount="100">100</button>
+                <button class="btn buy-btn" data-item-name="${item.name}" data-amount="max">${t('btn_max')}</button>
             </div>
         `;
         DOM.storeItems.appendChild(itemDiv);


### PR DESCRIPTION
This change adds three new buttons to the store for purchasing seeds:
- Buy 10
- Buy 100
- Buy Max (maximum affordable)

This is in addition to the existing functionality of buying a custom amount of seeds using the input field.

The UI in `src/modules/ui.js` has been updated to include the new buttons. The event listener in `src/main.js` has been updated to handle the logic for the new purchase options.