### PR TITLE
feat: Replace button text with icons and move clear progress button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -489,8 +489,8 @@ h1 {
 }
 
 .reset-container {
-    position: fixed;
-    bottom: 10px;
-    left: 10px;
+    position: absolute;
+    top: 10px;
+    left: 350px;
     z-index: 1000;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,9 +2,12 @@ import { setLanguage, t } from './modules/localization.js';
 import { DOM, renderAll, renderOrderTimers } from './modules/ui.js';
 import { plantSeed, harvestCrop, sellCrop, buyUpgrade, gameTick, buySeed, fulfillOrder, forceGenerateOrder, increaseTrust, buyBuilding, startProduction, devAddAllProducts, toggleBuildingAutomation, addXp } from './modules/game.js';
 import { player, field, warehouse, saveGameState, clearGameState, loadGameState } from './modules/state.js';
-import { leveling, store } from './modules/config.js';
+import { leveling, store, uiIcons } from './modules/config.js';
 
 document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('clear-data-btn').innerHTML = uiIcons.clear;
+    DOM.langEnBtn.innerHTML = uiIcons.en;
+    DOM.langUkBtn.innerHTML = uiIcons.uk;
     let gameLoopInterval;
     let orderTimerInterval;
 

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -23,6 +23,15 @@ export const store = [
     { name: 'blueberry_seed', price: 60, type: 'seed', requiredLevel: 7 }
 ];
 
+export const uiIcons = {
+    clear: '🗑️',
+    store: '🛍️',
+    market: '💹',
+    reference: '❓',
+    en: '🇬🇧',
+    uk: '🇺🇦'
+};
+
 export const cropTypes = {
     'wheat': {
         icon: '🌾',

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -1,6 +1,6 @@
 import { t } from './localization.js';
 import { player, field, warehouse, marketState, customers } from './state.js';
-import { NUM_ROWS, NUM_COLS, store, cropTypes, upgrades, customerConfig, buildings } from './config.js';
+import { NUM_ROWS, NUM_COLS, store, cropTypes, upgrades, customerConfig, buildings, uiIcons } from './config.js';
 
 export const DOM = {
     fieldGrid: document.getElementById('field-grid'),
@@ -316,9 +316,9 @@ function renderStaticUI() {
     DOM.warehouseTitle.textContent = t('warehouse_title');
     DOM.fieldTitle.textContent = t('field_title');
     document.querySelector('#buildings-container h2').textContent = t('buildings_title');
-    DOM.openStoreBtn.textContent = t('btn_store');
-    DOM.openMarketBtn.textContent = t('btn_market');
-    DOM.openRefBtn.textContent = t('btn_reference');
+    DOM.openStoreBtn.innerHTML = uiIcons.store;
+    DOM.openMarketBtn.innerHTML = uiIcons.market;
+    DOM.openRefBtn.innerHTML = uiIcons.reference;
     DOM.seedsTabBtn.textContent = t('seeds_tab');
     DOM.productionTabBtn.textContent = t('production_tab');
     DOM.upgradesTabBtn.textContent = t('upgrades_tab');


### PR DESCRIPTION
This commit replaces the text on the clear progress, store, market, reference, and language buttons with icons. The clear progress button has also been moved to the upper left corner of the screen.

A new `uiIcons` object has been added to `src/modules/config.js` to store the icons, and the relevant UI rendering functions have been updated to use these icons.