### PR TITLE
Feat: Implement and expand building production improvements

### DIFF
--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -444,10 +444,18 @@ function renderBuildings() {
             }
 
             let statusHtml = '';
-            if (playerBuilding.production) {
-                const recipe = building.recipes[playerBuilding.production.recipeIndex];
-                const timeLeft = Math.round((playerBuilding.production.startTime + recipe.productionTime - Date.now()) / 1000);
-                statusHtml = `<div class="building-status">${t('status_producing')} (${t('status_time_left', { time: timeLeft })})</div>`;
+            if (playerBuilding.production.length > 0) {
+                const job = playerBuilding.production[0];
+                const recipe = building.recipes[job.recipeIndex];
+                const effectiveTime = recipe.productionTime * (1 - (player.upgrades.productionSpeed || 0));
+                const timeLeft = Math.round((job.startTime + effectiveTime - Date.now()) / 1000);
+
+                let queueStatus = '';
+                if (playerBuilding.production.length > 1) {
+                    queueStatus = ` (+${playerBuilding.production.length - 1} in queue)`;
+                }
+
+                statusHtml = `<div class="building-status">${t('status_producing')} (${t('status_time_left', { time: Math.max(0, timeLeft) })}) ${queueStatus}</div>`;
             } else {
                 building.recipes.forEach((recipe, index) => {
                     const inputs = Object.entries(recipe.input).map(([key, value]) => `${value} ${t(key)}`).join(', ');


### PR DESCRIPTION
This change implements the logic for building production upgrades (speed, efficiency, luck, and volume) which were previously defined but not used in the game. It also expands the available upgrades by adding a new tier and adds the necessary localization.

Key changes:
- Rewrote `updateProduction` to correctly apply all building upgrade effects to the production queue.
- Fixed bugs related to production queue handling.
- Modified `startProduction` to handle the `productionVolume` upgrade as a batch size multiplier for both input and output.
- Standardized upgrade-related property names in the initial game state for consistency.
- Added a new tier of building upgrades to `config.js` for end-game content.
- Added localization for all new and existing building upgrades in English and Ukrainian.
- Ensured that production output is always an integer value.
- Fixed a UI bug in `renderBuildings` that caused a crash when rendering the production queue.