### PR TITLE
feat: Add a debug menu for testing purposes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -537,6 +537,20 @@ h1 {
     z-index: 1000;
 }
 
+#debug-controls {
+    position: absolute;
+    top: 50px;
+    right: 10px;
+    z-index: 1001;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+#debug-controls.hidden {
+    display: none;
+}
+
 /* Mobile Landscape */
 @media (max-height: 480px) and (orientation: landscape) {
     h1 {

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
 <div id="game-wrapper">
     <div id="notification-banner" class="notification"></div>
+    <div id="debug-controls" class="hidden"></div>
     <div class="language-switcher">
         <button id="lang-en" class="btn lang-btn" data-lang="en">EN</button>
         <button id="lang-uk" class="btn lang-btn" data-lang="uk">UK</button>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { setLanguage, t } from './modules/localization.js';
-import { DOM, renderAll, renderOrderTimers } from './modules/ui.js';
-import { plantSeed, harvestCrop, sellCrop, buyUpgrade, gameTick, buySeed, fulfillOrder, forceGenerateOrder, increaseTrust, buyBuilding, startProduction, devAddAllProducts, toggleBuildingAutomation, addXp } from './modules/game.js';
+import { DOM, renderAll, renderOrderTimers, toggleDebugMenu } from './modules/ui.js';
+import { plantSeed, harvestCrop, sellCrop, buyUpgrade, gameTick, buySeed, fulfillOrder, forceGenerateOrder, increaseTrust, buyBuilding, startProduction, devAddAllProducts, toggleBuildingAutomation, addXp, devAddMoney, devAddLevel } from './modules/game.js';
 import { player, field, warehouse, saveGameState, clearGameState, loadGameState } from './modules/state.js';
 import { leveling, store } from './modules/config.js';
 
@@ -243,4 +243,36 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }, 1000); // Main game loop
     orderTimerInterval = setInterval(renderOrderTimers, 1000); // Timer-only render loop
+
+    // --- Debug ---
+    let sequence = '';
+    const cheatCode = 'shnaider';
+    document.addEventListener('keydown', (e) => {
+        sequence += e.key.toLowerCase();
+        if (sequence.length > cheatCode.length) {
+            sequence = sequence.slice(1);
+        }
+        if (sequence === cheatCode) {
+            toggleDebugMenu();
+            sequence = ''; // Reset sequence
+        }
+    });
+
+    DOM.debugControls.addEventListener('click', (e) => {
+        const id = e.target.id;
+        let stateChanged = false;
+
+        if (id === 'dev-add-level') {
+            stateChanged = devAddLevel();
+        } else if (id === 'dev-add-money') {
+            stateChanged = devAddMoney();
+        } else if (id === 'dev-add-products') {
+            stateChanged = devAddAllProducts();
+        }
+
+        if (stateChanged) {
+            renderAll();
+            saveGameState();
+        }
+    });
 });

--- a/src/modules/game.js
+++ b/src/modules/game.js
@@ -577,7 +577,19 @@ export function forceGenerateOrder() {
 
 export function devAddAllProducts() {
     for (const item in warehouse) {
-        warehouse[item] += 100;
+        if (warehouse.hasOwnProperty(item)) {
+            warehouse[item] += 1000;
+        }
     }
+    return true;
+}
+
+export function devAddMoney() {
+    player.money += 1000000;
+    return true;
+}
+
+export function devAddLevel() {
+    addXp(player.xpToNextLevel - player.xp);
     return true;
 }

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -54,10 +54,12 @@ export const DOM = {
     levelUpModal: document.getElementById('level-up-modal'),
     levelUpTitle: document.getElementById('level-up-title'),
     levelUpUnlocks: document.getElementById('level-up-unlocks'),
-    levelUpCloseBtn: document.querySelector('.level-up-close')
+    levelUpCloseBtn: document.querySelector('.level-up-close'),
+    debugControls: document.getElementById('debug-controls')
 };
 
 let notificationTimeout;
+let debugMenuInitialized = false;
 
 export function showNotification(message) {
     if (notificationTimeout) {
@@ -622,4 +624,26 @@ export function showSimpleLevelUpModal(level, message) {
     DOM.levelUpTitle.textContent = t('level_up_title', { level });
     DOM.levelUpUnlocks.innerHTML = `<p>${message}</p>`;
     DOM.levelUpModal.style.display = 'block';
+}
+
+export function toggleDebugMenu() {
+    if (!debugMenuInitialized) {
+        const buttons = [
+            { id: 'dev-add-level', text: '+1 Level' },
+            { id: 'dev-add-money', text: '+1M Money' },
+            { id: 'dev-add-products', text: '+1k Products' }
+        ];
+
+        buttons.forEach(btnInfo => {
+            const button = document.createElement('button');
+            button.id = btnInfo.id;
+            button.textContent = btnInfo.text;
+            button.classList.add('btn');
+            DOM.debugControls.appendChild(button);
+        });
+
+        debugMenuInitialized = true;
+    }
+
+    DOM.debugControls.classList.toggle('hidden');
 }


### PR DESCRIPTION
This commit introduces a debug menu that can be activated by typing the sequence "shnaider".

The menu includes buttons to:
- Add 1,000,000 money
- Add 1 level
- Add 1,000 of all products

The debug panel is hidden by default and appears in the top-right corner when activated. This feature is intended for development and testing to make it easier to check game balance and new features.