### PR TITLE
fix(ui): Update market, orders, and production on harvest

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (stateChanged) {
                 scheduleUpdate('field');
                 scheduleUpdate('warehouse');
+                scheduleUpdate('market');
+                scheduleUpdate('orders');
+                scheduleUpdate('buildings');
                 saveGameState();
             }
         }


### PR DESCRIPTION
When a crop was harvested, the UI for the market, orders, and production was not updated to reflect the new items in the warehouse. This meant the player could not sell the newly harvested crops or use them to fulfill orders or start production without a page refresh.

This change adds calls to `scheduleUpdate` for the 'market', 'orders', and 'buildings' components within the harvest event listener. This ensures that these UI elements are refreshed immediately after a harvest, providing a seamless user experience.